### PR TITLE
Fixed java.net.SocketException: Connection reset

### DIFF
--- a/bukkit/src/main/java/com/vexsoftware/votifier/NuVotifierBukkit.java
+++ b/bukkit/src/main/java/com/vexsoftware/votifier/NuVotifierBukkit.java
@@ -437,6 +437,17 @@ public class NuVotifierBukkit extends JavaPlugin implements VoteHandler, Votifie
     }
 
     @Override
+    public void onConnectionReset(String remoteAddress, boolean voteAlreadyCompleted) {
+        if (debug) {
+            if (voteAlreadyCompleted) {
+                getLogger().log(Level.INFO, "Connection reset from " + remoteAddress + " after vote was processed");
+            } else {
+                getLogger().log(Level.INFO, "Connection reset from " + remoteAddress + " during vote processing");
+            }
+        }
+    }
+
+    @Override
     public void onForward(final Vote v) {
         if (debug) {
             getLogger().info("Got a forwarded vote -> " + v);

--- a/common/src/main/java/com/vexsoftware/votifier/VoteHandler.java
+++ b/common/src/main/java/com/vexsoftware/votifier/VoteHandler.java
@@ -2,7 +2,6 @@ package com.vexsoftware.votifier;
 
 import com.vexsoftware.votifier.model.Vote;
 import com.vexsoftware.votifier.net.VotifierSession;
-import io.netty.channel.Channel;
 
 public interface VoteHandler {
 
@@ -10,5 +9,10 @@ public interface VoteHandler {
 
     default void onError(Throwable throwable, boolean voteAlreadyCompleted, String remoteAddress) {
         throw new RuntimeException("Unimplemented onError handler");
+    }
+
+    default void onConnectionReset(String remoteAddress, boolean voteAlreadyCompleted) {
+        // Log connection reset at INFO level since it's a normal network event
+        System.out.println("[Votifier] Connection reset from " + remoteAddress + (voteAlreadyCompleted ? " (vote processed)" : " (vote incomplete)"));
     }
 }

--- a/common/src/main/java/com/vexsoftware/votifier/net/VotifierServerBootstrap.java
+++ b/common/src/main/java/com/vexsoftware/votifier/net/VotifierServerBootstrap.java
@@ -8,10 +8,7 @@ import com.vexsoftware.votifier.support.forwarding.cache.VoteCache;
 import com.vexsoftware.votifier.support.forwarding.proxy.ProxyForwardingVoteSource;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
-import io.netty.channel.Channel;
-import io.netty.channel.ChannelFutureListener;
-import io.netty.channel.ChannelInitializer;
-import io.netty.channel.EventLoopGroup;
+import io.netty.channel.*;
 import io.netty.channel.epoll.Epoll;
 import io.netty.channel.epoll.EpollEventLoopGroup;
 import io.netty.channel.epoll.EpollServerSocketChannel;
@@ -76,6 +73,10 @@ public class VotifierServerBootstrap {
         new ServerBootstrap()
                 .channel(USE_EPOLL ? EpollServerSocketChannel.class : NioServerSocketChannel.class)
                 .group(bossLoopGroup, eventLoopGroup)
+                .option(ChannelOption.SO_BACKLOG, 128)
+                .childOption(ChannelOption.SO_KEEPALIVE, true)
+                .childOption(ChannelOption.TCP_NODELAY, true)
+                .childOption(ChannelOption.CONNECT_TIMEOUT_MILLIS, 10000)
                 .childHandler(new ChannelInitializer<SocketChannel>() {
                     @Override
                     protected void initChannel(SocketChannel channel) {


### PR DESCRIPTION
Fixed this warning that got thrown from time to time:

[15:33:13 WARN]: [Votifier] Unable to process vote from /205.210.31.177:61910
  java.net.SocketException: Connection reset
          at java.base/sun.nio.ch.SocketChannelImpl.throwConnectionReset(SocketChannelImpl.java:401) ~[?:?]
          at java.base/sun.nio.ch.SocketChannelImpl.read(SocketChannelImpl.java:434) ~[?:?]
          at nuvotifier-bukkit-3.3.5-dist.jar/com.vexsoftware.votifier.libs.netty.buffer.PooledByteBuf.setBytes(PooledByteBuf.java:255) ~[nuvotifier-bukkit-3.3.5-dist.jar:?]
          at nuvotifier-bukkit-3.3.5-dist.jar/com.vexsoftware.votifier.libs.netty.buffer.AbstractByteBuf.writeBytes(AbstractByteBuf.java:1132) ~[nuvotifier-bukkit-3.3.5-dist.jar:?]
          at nuvotifier-bukkit-3.3.5-dist.jar/com.vexsoftware.votifier.libs.netty.channel.socket.nio.NioSocketChannel.doReadBytes(NioSocketChannel.java:356) ~[nuvotifier-bukkit-3.3.5-dist.jar:?]
          at nuvotifier-bukkit-3.3.5-dist.jar/com.vexsoftware.votifier.libs.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:151) ~[nuvotifier-bukkit-3.3.5-dist.jar:?]
          at nuvotifier-bukkit-3.3.5-dist.jar/com.vexsoftware.votifier.libs.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:788) ~[nuvotifier-bukkit-3.3.5-dist.jar:?]
          at nuvotifier-bukkit-3.3.5-dist.jar/com.vexsoftware.votifier.libs.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:724) ~[nuvotifier-bukkit-3.3.5-dist.jar:?]
          at nuvotifier-bukkit-3.3.5-dist.jar/com.vexsoftware.votifier.libs.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:650) ~[nuvotifier-bukkit-3.3.5-dist.jar:?]
          at nuvotifier-bukkit-3.3.5-dist.jar/com.vexsoftware.votifier.libs.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:562) ~[nuvotifier-bukkit-3.3.5-dist.jar:?]
          at nuvotifier-bukkit-3.3.5-dist.jar/com.vexsoftware.votifier.libs.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997) ~[nuvotifier-bukkit-3.3.5-dist.jar:?]
          at nuvotifier-bukkit-3.3.5-dist.jar/com.vexsoftware.votifier.libs.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74) ~[nuvotifier-bukkit-3.3.5-dist.jar:?]
          at nuvotifier-bukkit-3.3.5-dist.jar/com.vexsoftware.votifier.libs.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) ~[nuvotifier-bukkit-3.3.5-dist.jar:?]
          at java.base/java.lang.Thread.run(Thread.java:1583) ~[?:?]